### PR TITLE
Fix float error on CPU Cache

### DIFF
--- a/setup_moneroocean_miner.sh
+++ b/setup_moneroocean_miner.sh
@@ -94,7 +94,7 @@ fi
 CPU_L1_CACHE=`echo "$LSCPU" | grep "^L1d" | cut -d':' -f2 | sed "s/^[ \t]*//" | sed "s/ \?K\(iB\)\?\$//"`
 if echo "$CPU_L1_CACHE" | grep MiB >/dev/null; then
   CPU_L1_CACHE=`echo "$CPU_L1_CACHE" | sed "s/ MiB\$//"`
-  CPU_L1_CACHE=$(( $CPU_L1_CACHE * 1024))
+  CPU_L1_CACHE=$(bc -l <<< "scale=0;(${CPU_L1_CACHE} * 1024)/1")
 fi
 if [ -z "$CPU_L1_CACHE" ]; then
   echo "WARNING: Can't get L1 CPU cache from lscpu output"
@@ -103,7 +103,7 @@ fi
 CPU_L2_CACHE=`echo "$LSCPU" | grep "^L2" | cut -d':' -f2 | sed "s/^[ \t]*//" | sed "s/ \?K\(iB\)\?\$//"`
 if echo "$CPU_L2_CACHE" | grep MiB >/dev/null; then
   CPU_L2_CACHE=`echo "$CPU_L2_CACHE" | sed "s/ MiB\$//"`
-  CPU_L2_CACHE=$(( $CPU_L2_CACHE * 1024))
+  CPU_L2_CACHE=$(bc -l <<< "scale=0;(${CPU_L2_CACHE} * 1024)/1")
 fi
 if [ -z "$CPU_L2_CACHE" ]; then
   echo "WARNING: Can't get L2 CPU cache from lscpu output"
@@ -112,7 +112,7 @@ fi
 CPU_L3_CACHE=`echo "$LSCPU" | grep "^L3" | cut -d':' -f2 | sed "s/^[ \t]*//" | sed "s/ \?K\(iB\)\?\$//"`
 if echo "$CPU_L3_CACHE" | grep MiB >/dev/null; then
   CPU_L3_CACHE=`echo "$CPU_L3_CACHE" | sed "s/ MiB\$//"`
-  CPU_L3_CACHE=$(( $CPU_L3_CACHE * 1024))
+  CPU_L3_CACHE=$(bc -l <<< "scale=0;(${CPU_L3_CACHE} * 1024)/1")
 fi
 if [ -z "$CPU_L3_CACHE" ]; then
   echo "WARNING: Can't get L3 CPU cache from lscpu output"


### PR DESCRIPTION
My CPU cache has a floating number thus it generated errors since bash doesn't allow operations on float.
I added the bc command & truncated the number.